### PR TITLE
Miscellaneous improvements | Management Users, Comment notifications and more

### DIFF
--- a/src/components/Buttons/FloatingButton.jsx
+++ b/src/components/Buttons/FloatingButton.jsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {
-  Slide, Icon, useScrollTrigger,
+  Slide,
+  Icon,
+  useScrollTrigger,
+  CircularProgress,
 } from '@material-ui/core';
 
 import { CustomFab } from '@/components/Buttons/styles';

--- a/src/components/Buttons/FloatingButton.jsx
+++ b/src/components/Buttons/FloatingButton.jsx
@@ -16,6 +16,9 @@ function FloatingButton(props) {
     icon,
     color,
     direction,
+    loading,
+    loadingIndicatorColor,
+    loadingIndicatorSize,
   } = props;
 
   const params = { target: window ? window() : undefined, disableHysteresis: true };
@@ -27,7 +30,19 @@ function FloatingButton(props) {
         color={color}
         onClick={action}
       >
-        <Icon>{icon}</Icon>
+        { loading
+          && (
+            <CircularProgress
+              color={loadingIndicatorColor}
+              size={loadingIndicatorSize}
+            />
+          )}
+        {icon && !loading
+          && (
+            <Icon>
+              {icon}
+            </Icon>
+          )}
       </CustomFab>
     </Slide>
   ) : null;
@@ -44,6 +59,13 @@ FloatingButton.propTypes = {
     'secondary',
   ]),
   direction: PropTypes.string,
+  loading: PropTypes.bool,
+  loadingIndicatorColor: PropTypes.oneOf([
+    'inherit',
+    'primary',
+    'secondary',
+  ]),
+  loadingIndicatorSize: PropTypes.number,
 };
 
 FloatingButton.defaultProps = {
@@ -51,5 +73,8 @@ FloatingButton.defaultProps = {
   icon: 'keyboard_arrow_up',
   color: 'primary',
   direction: 'up',
+  loading: false,
+  loadingIndicatorColor: 'inherit',
+  loadingIndicatorSize: 25,
 };
 export default FloatingButton;

--- a/src/components/Comments/UnreadComments.jsx
+++ b/src/components/Comments/UnreadComments.jsx
@@ -201,16 +201,18 @@ function UnreadComments(props) {
                   <Typography component="h3" variant="body2">
                     Parabéns!! Você está em dia com seus leitores.
                   </Typography>
-                  <CustomLink to="/comments">
-                    <Button
-                      variant="text"
-                      color="primary"
-                      size="small"
-                      onClick={closeMenuNotifications}
-                    >
-                      Ir para comentários
-                    </Button>
-                  </CustomLink>
+                  <Box mt={1}>
+                    <CustomLink to="/comments">
+                      <Button
+                        variant={theme === 'dark' ? 'contained' : 'text'}
+                        color="primary"
+                        size="small"
+                        onClick={closeMenuNotifications}
+                      >
+                        Visualizar comentários
+                      </Button>
+                    </CustomLink>
+                  </Box>
                 </Box>
               )
             }

--- a/src/components/Menu/AppBar.jsx
+++ b/src/components/Menu/AppBar.jsx
@@ -114,7 +114,7 @@ function AppBar(props) {
                     person_outline
                   </Icon>
                   <Typography component="span" variant="body2">
-                    Meus dados
+                    Minha conta
                   </Typography>
                 </Box>
               </MenuItem>

--- a/src/components/Menu/Drawer.jsx
+++ b/src/components/Menu/Drawer.jsx
@@ -146,7 +146,7 @@ function DrawerMenu(props) {
                   person_outline
                 </Icon>
                 <Typography component="span" variant="body2">
-                  Meus dados
+                  Minha conta
                 </Typography>
               </Box>
             </CustomListItem>

--- a/src/components/Tickets/SendTickets/AccountRecuperation.jsx
+++ b/src/components/Tickets/SendTickets/AccountRecuperation.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
+import { reactRouterParams } from '@/types';
 
 import {
   Container,
@@ -189,8 +190,7 @@ function AccountRecuperation(props) {
 }
 
 AccountRecuperation.propTypes = {
-  // eslint-disable-next-line react/forbid-prop-types
-  params: PropTypes.object.isRequired,
+  params: reactRouterParams.isRequired,
   callToast: PropTypes.func.isRequired,
 };
 

--- a/src/components/Users/Management/DialogConfirmAdminPassword.jsx
+++ b/src/components/Users/Management/DialogConfirmAdminPassword.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
+import { appTheme } from '@/types';
 
 import {
   Dialog,
@@ -25,6 +26,7 @@ function ConfirmAdminPassword(props) {
     open,
     closeDialog,
     callToast,
+    theme,
   } = props;
 
   const [validating, setValidating] = useState(false);
@@ -82,7 +84,8 @@ function ConfirmAdminPassword(props) {
       </DialogContent>
       <DialogActions>
         <Button
-          color="primary"
+          variant={theme === 'dark' ? 'contained' : 'text'}
+          size="small"
           onClick={close}
           disabled={validating}
         >
@@ -90,6 +93,8 @@ function ConfirmAdminPassword(props) {
         </Button>
         <Button
           color="primary"
+          variant={theme === 'dark' ? 'contained' : 'text'}
+          size="small"
           onClick={validatePassword}
           disabled={validating}
         >
@@ -104,13 +109,14 @@ ConfirmAdminPassword.propTypes = {
   open: PropTypes.bool,
   closeDialog: PropTypes.func.isRequired,
   callToast: PropTypes.func.isRequired,
+  theme: appTheme.isRequired,
 };
 
 ConfirmAdminPassword.defaultProps = {
   open: false,
 };
 
-const mapStateToProps = (state) => ({ toast: state.config });
+const mapStateToProps = (state) => ({ toast: state.config, theme: state.theme });
 const mapDispatchToProps = (dispatch) => bindActionCreators({ callToast: toastEmitter }, dispatch);
 
 export default connect(mapStateToProps, mapDispatchToProps)(ConfirmAdminPassword);

--- a/src/components/Users/Management/DialogConfirmRemoveUser.jsx
+++ b/src/components/Users/Management/DialogConfirmRemoveUser.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { userType } from '@/types';
+import { userType, appTheme } from '@/types';
 
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
@@ -26,6 +26,7 @@ function ConfirmRemoveUser(props) {
     closeDialog,
     callToast,
     user,
+    theme,
   } = props;
 
   const [removing, setRemoving] = useState(false);
@@ -66,7 +67,8 @@ function ConfirmRemoveUser(props) {
       </DialogContent>
       <DialogActions>
         <Button
-          color="primary"
+          variant={theme === 'dark' ? 'contained' : 'text'}
+          size="small"
           onClick={closeDialog}
           disabled={removing}
         >
@@ -74,6 +76,8 @@ function ConfirmRemoveUser(props) {
         </Button>
         <Button
           color="primary"
+          variant={theme === 'dark' ? 'contained' : 'text'}
+          size="small"
           disabled={removing}
           onClick={remove}
         >
@@ -89,13 +93,14 @@ ConfirmRemoveUser.propTypes = {
   closeDialog: PropTypes.func.isRequired,
   callToast: PropTypes.func.isRequired,
   user: userType.isRequired,
+  theme: appTheme.isRequired,
 };
 
 ConfirmRemoveUser.defaultProps = {
   open: false,
 };
 
-const mapStateToProps = (state) => ({ toast: state.config });
+const mapStateToProps = (state) => ({ toast: state.config, theme: state.theme });
 const mapDispatchToProps = (dispatch) => bindActionCreators({ callToast: toastEmitter }, dispatch);
 
 export default connect(mapStateToProps, mapDispatchToProps)(ConfirmRemoveUser);

--- a/src/components/Users/Management/DialogConfirmRestoreUser.jsx
+++ b/src/components/Users/Management/DialogConfirmRestoreUser.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { userType } from '@/types';
+import { userType, appTheme } from '@/types';
 
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
@@ -26,6 +26,7 @@ function ConfirmRestore(props) {
     closeDialog,
     callToast,
     user,
+    theme,
   } = props;
 
   const [restoring, setRestoring] = useState(false);
@@ -68,12 +69,16 @@ function ConfirmRestore(props) {
         <Button
           onClick={closeDialog}
           disabled={restoring}
+          variant={theme === 'dark' ? 'contained' : 'text'}
+          size="small"
         >
           Fechar
         </Button>
         <Button
           onClick={restore}
           color="primary"
+          variant={theme === 'dark' ? 'contained' : 'text'}
+          size="small"
           disabled={restoring}
         >
           Confirmar
@@ -88,6 +93,7 @@ ConfirmRestore.propTypes = {
   closeDialog: PropTypes.func.isRequired,
   callToast: PropTypes.func.isRequired,
   user: userType.isRequired,
+  theme: appTheme.isRequired,
 };
 
 ConfirmRestore.defaultProps = {
@@ -95,7 +101,7 @@ ConfirmRestore.defaultProps = {
 };
 
 
-const mapStateToProps = (state) => ({ toast: state.config });
+const mapStateToProps = (state) => ({ toast: state.config, theme: state.theme });
 const mapDispatchToProps = (dispatch) => bindActionCreators({ callToast: toastEmitter }, dispatch);
 
 export default connect(mapStateToProps, mapDispatchToProps)(ConfirmRestore);

--- a/src/components/Users/Management/DialogSetPassword.jsx
+++ b/src/components/Users/Management/DialogSetPassword.jsx
@@ -4,7 +4,7 @@
  */
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { userType } from '@/types';
+import { userType, appTheme } from '@/types';
 
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
@@ -32,6 +32,7 @@ function DialogSetPassword(props) {
     closeDialog,
     user,
     callToast,
+    theme,
   } = props;
 
   const [password, setPassword] = useState('');
@@ -87,7 +88,8 @@ function DialogSetPassword(props) {
       </DialogContent>
       <DialogActions>
         <Button
-          color="primary"
+          variant={theme === 'dark' ? 'contained' : 'text'}
+          size="small"
           onClick={closeDialog}
           disabled={saving}
         >
@@ -95,6 +97,8 @@ function DialogSetPassword(props) {
         </Button>
         <Button
           color="primary"
+          variant={theme === 'dark' ? 'contained' : 'text'}
+          size="small"
           onClick={changePassword}
         >
           Confirmar
@@ -109,13 +113,14 @@ DialogSetPassword.propTypes = {
   closeDialog: PropTypes.func.isRequired,
   user: userType.isRequired,
   callToast: PropTypes.func.isRequired,
+  theme: appTheme.isRequired,
 };
 
 DialogSetPassword.defaultProps = {
   open: false,
 };
 
-const mapStateToProps = (state) => ({ user: state.user });
+const mapStateToProps = (state) => ({ user: state.user, theme: state.theme });
 const mapDispatchToProps = (dispatch) => bindActionCreators({ callToast: toastEmitter }, dispatch);
 
 export default connect(mapStateToProps, mapDispatchToProps)(DialogSetPassword);

--- a/src/components/Users/Management/RemovedUsers.jsx
+++ b/src/components/Users/Management/RemovedUsers.jsx
@@ -342,7 +342,7 @@ function RemovedUsers(props) {
                       <TableCell>
                         <CustomIconButton
                           icon="restore_from_trash"
-                          color="primary"
+                          color={theme === 'dark' ? 'inherit' : 'primary'}
                           tooltip={
                           (
                             <Typography component="span" variant="body2">
@@ -375,7 +375,13 @@ function RemovedUsers(props) {
           )}
       </DialogContent>
       <DialogActions>
-        <Button onClick={close} color="primary" autoFocus>
+        <Button
+          onClick={close}
+          color="primary"
+          variant={theme === 'dark' ? 'contained' : 'text'}
+          size="small"
+          autoFocus
+        >
           Fechar
         </Button>
       </DialogActions>

--- a/src/components/Users/Management/UserForm.jsx
+++ b/src/components/Users/Management/UserForm.jsx
@@ -205,7 +205,7 @@ function UserForm(props) {
         icon="person_add"
       />
       { redirect && <Redirect to="/users" />}
-      { !loading && <FloatingButton action={save} icon="save" />}
+      { !loading && <FloatingButton action={save} icon="save" loading={saving} />}
       <DialogConfirmRemoveUser
         open={confirmRemoveUserDialog}
         closeDialog={hideConfirmRemoveUserDialog}

--- a/src/components/Users/Management/UserFormHud.jsx
+++ b/src/components/Users/Management/UserFormHud.jsx
@@ -87,7 +87,7 @@ function UserFormHud(props) {
       { user._id
         && (
           <CustomButton
-            color="inherit"
+            color="default"
             size="small"
             iconSize="small"
             icon="lock"
@@ -114,7 +114,10 @@ function UserFormHud(props) {
         <MenuItem onClick={toogleSendEmail}>
           <Box display="flex" flexDirection="column" flexWrap="wrap">
             <Typography component="span" variant="body1">
-              Notificar mudanças:
+              Notificar
+              {' '}
+              {user._id ? 'mudanças' : 'cadastro'}
+              :
               {' '}
               {sendEmail ? 'ativado' : 'desativado'}
             </Typography>
@@ -127,9 +130,9 @@ function UserFormHud(props) {
               }}
               align="center"
             >
-              Ao realizar alterações no cadastro do usuário,
-              o mesmo receberá notificação de mudança caso
-              esteja habilitado a opção.
+              {user._id
+                ? 'Se ativo o usuário receberá uma notificação de mudanças no cadastro.'
+                : 'Se ativo, o usuário receberá um e-mail de notificação contendo as credenciais de acesso ao painel'}
             </Typography>
           </Box>
         </MenuItem>

--- a/src/components/Users/Management/Users.jsx
+++ b/src/components/Users/Management/Users.jsx
@@ -353,7 +353,7 @@ function Users(props) {
                         <CustomLink to={`/user/${elem._id}`}>
                           <CustomIconButton
                             icon="edit"
-                            color="primary"
+                            color={theme === 'dark' ? 'inherit' : 'primary'}
                             tooltip={<Typography component="span" variant="body2">Editar</Typography>}
                           />
                         </CustomLink>


### PR DESCRIPTION
- [x] Added support to `dark theme` on comments notifications, especially in `go to comments` button :wrench:
- [x] Changed `react router params` prop-type in `tickets/AccountRecuperation.jsx`, the last type was `object`, the most recent is specified types (`reactRouterParams`) :wrench: 
- [x] Changed identifier interface to access `MyAccount` section, the new name are `Minha conta`[PT-BR] or `My Account` [ENG] :hammer_and_wrench: 
- [x] Fixed conflicts caused by **merge with rebase**
- [x] Added support to `dark theme` in several user components (Dialogs, forms and lists). Especially buttons :wrench: 
- [x] Fixed change password button in management user form :hammer_and_wrench: 
- [x] Added loading indicator to floating button in management user form :rocket: 
