### PR TITLE
Enhanced styles for Themes and Categories sections

### DIFF
--- a/src/components/Categories/Categories.jsx
+++ b/src/components/Categories/Categories.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { userType } from '@/types';
+import { userType, appTheme } from '@/types';
 import {
   Container,
   Table,
@@ -50,6 +50,7 @@ import {
 function Categories(props) {
   const {
     user,
+    theme,
   } = props;
 
   const [categories, setCategories] = useState([]);
@@ -273,7 +274,7 @@ function Categories(props) {
                   <TableCell scope="_id">
                     <CustomIconButton
                       icon="edit"
-                      color="primary"
+                      color={theme === 'dark' ? 'inherit' : 'primary'}
                       tooltip={<Typography component="span" variant="body2">Editar</Typography>}
                       onClick={() => selectCategory(elem, 'edit')}
                     />
@@ -313,9 +314,10 @@ function Categories(props) {
 
 Categories.propTypes = {
   user: userType.isRequired,
+  theme: appTheme.isRequired,
 };
 
-const mapStateToProps = (state) => ({ user: state.user, toast: state.config });
+const mapStateToProps = (state) => ({ user: state.user, toast: state.config, theme: state.theme });
 const mapDispatchToProps = (dispatch) => bindActionCreators({ callToast: toastEmitter }, dispatch);
 
 export default connect(mapStateToProps, mapDispatchToProps)(Categories);

--- a/src/components/Categories/Form.jsx
+++ b/src/components/Categories/Form.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { categoryType } from '@/types';
+import { categoryType, appTheme } from '@/types';
 
 import {
   Icon,
@@ -29,6 +29,7 @@ import {
   CustomTextField,
   CustomFormGroup,
   CustomInputLabel,
+  searchThemeStyle,
 } from './styles';
 
 function CategoryForm(props) {
@@ -37,6 +38,7 @@ function CategoryForm(props) {
     propCategory,
     open,
     onClose,
+    theme,
   } = props;
 
   const [category, setCategory] = useState({});
@@ -126,15 +128,15 @@ function CategoryForm(props) {
           name: '', alias: '', theme: null, description: '',
         });
       } else {
-        const theme = propCategory.theme || {};
+        const currentTheme = propCategory.theme || {};
 
         // Set label and value properties to display in async-select component
         const currentCategory = {
           ...propCategory,
           theme: {
-            ...theme,
-            label: theme.name,
-            value: theme._id,
+            ...currentTheme,
+            label: currentTheme.name,
+            value: currentTheme._id,
           },
         };
 
@@ -183,10 +185,11 @@ function CategoryForm(props) {
             onChange={(event) => handleChange(event, 'alias')}
           />
           <CustomFormGroup>
-            <CustomInputLabel>
+            <CustomInputLabel theme={theme}>
               Tema
             </CustomInputLabel>
             <AsyncSelect
+              styles={searchThemeStyle({ theme })}
               cacheOptions
               value={category.theme || null}
               isClearable
@@ -215,10 +218,10 @@ function CategoryForm(props) {
         </Box>
       </DialogContent>
       <DialogActions style={{ margin: 10 }}>
-        <Button variant="contained" onClick={() => close()}>
+        <Button variant="contained" size="small" onClick={close}>
           Fechar
         </Button>
-        <Button variant="contained" color="primary" onClick={save}>
+        <Button variant="contained" size="small" color="primary" onClick={save}>
           Salvar
         </Button>
       </DialogActions>
@@ -231,6 +234,7 @@ CategoryForm.propTypes = {
   propCategory: categoryType.isRequired,
   open: PropTypes.bool,
   onClose: PropTypes.func.isRequired,
+  theme: appTheme.isRequired,
 };
 
 CategoryForm.defaultProps = {
@@ -238,7 +242,7 @@ CategoryForm.defaultProps = {
 };
 
 
-const mapStateToProps = (state) => ({ toast: state.config });
+const mapStateToProps = (state) => ({ toast: state.config, theme: state.theme });
 const mapDispatchToProps = (dispatch) => bindActionCreators({ callToast: toastEmitter }, dispatch);
 
 export default connect(mapStateToProps, mapDispatchToProps)(CategoryForm);

--- a/src/components/Categories/RemoveConfirmation.jsx
+++ b/src/components/Categories/RemoveConfirmation.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { categoryType } from '@/types';
+import { categoryType, appTheme } from '@/types';
 
 import {
   Dialog,
@@ -29,6 +29,7 @@ function RemoveConfirmation(props) {
     categoriesQuantity,
     page,
     callToast,
+    theme,
   } = props;
 
   const [loading, setLoading] = useState(false);
@@ -76,12 +77,12 @@ function RemoveConfirmation(props) {
       </DialogContent>
       <DialogActions>
         {!loading && (
-          <Button variant="contained" onClick={close}>
+          <Button variant={theme === 'dark' ? 'contained' : 'text'} size="small" onClick={close}>
             Fechar
           </Button>
         )}
         {!loading && (
-        <Button color="primary" variant="contained" onClick={remove}>
+        <Button color="primary" variant={theme === 'dark' ? 'contained' : 'text'} size="small" onClick={remove}>
           Excluir
         </Button>
         )}
@@ -97,13 +98,14 @@ RemoveConfirmation.propTypes = {
   categoriesQuantity: PropTypes.number.isRequired,
   page: PropTypes.number.isRequired,
   callToast: PropTypes.func.isRequired,
+  theme: appTheme.isRequired,
 };
 
 RemoveConfirmation.defaultProps = {
   open: false,
 };
 
-const mapStateToProps = (state) => ({ user: state.user, toast: state.config });
+const mapStateToProps = (state) => ({ user: state.user, toast: state.config, theme: state.theme });
 const mapDispatchToProps = (dispatch) => bindActionCreators({ callToast: ToastEmitter }, dispatch);
 
 export default connect(mapStateToProps, mapDispatchToProps)(RemoveConfirmation);

--- a/src/components/Categories/styles.js
+++ b/src/components/Categories/styles.js
@@ -12,6 +12,8 @@ import { Link } from 'react-router-dom';
 import SearchBar from 'material-ui-search-bar';
 import { devices } from '@/config/devices';
 
+import { COLOR_APP, COLOR_APP_LIGHT } from '@/config/dataProperties';
+
 export const HudLink = styled(Link)({
   textDecoration: 'none',
   [devices.tablet]: {
@@ -78,4 +80,43 @@ export const TableWrapper = styled(Container)({
     fontSize: '0.875rem !important',
     fontWeight: '400 !important',
   },
+});
+
+/**
+ * @function
+ * @description The styles of `react-select` component, @see https://react-select.com/styles#style-object
+ * @param {Object} props Parent props
+ * @returns The styles
+ */
+export const searchThemeStyle = (props) => ({
+  control: (provided, state) => ({
+    ...provided,
+    backgroundColor: props.theme === 'dark' ? '#424242' : '#fff', // #424242 equal to `dark theme`
+    borderColor: state.isFocused ? '#8a05be' : `${props.theme === 'dark' ? '#fff' : 'rgba(0,0,0,.42)'}`, // rgba(0,0,0,.42) equal to default `TextField` border color
+    boxShadow: state.isFocused ? `0 0 0 1px ${COLOR_APP}` : 'none',
+    '&:hover': {
+      borderColor: state.isFocused ? COLOR_APP : `${props.theme === 'dark' ? '#fff' : 'rgba(0,0,0,.42)'}`,
+      boxShadow: `0 0 0 1px ${state.isFocused ? COLOR_APP : `${props.theme === 'dark' ? '#fff' : '#000'}`}`,
+    },
+  }),
+  input: (provided) => ({
+    ...provided,
+    color: props.theme === 'dark' ? '#fff' : 'currentColor',
+  }),
+  placeholder: (provided) => ({
+    ...provided,
+    color: props.theme === 'dark' ? '#fff' : 'currentColor',
+  }),
+  singleValue: (provided) => ({
+    ...provided,
+    color: props.theme === 'dark' ? '#fff' : 'currentColor',
+  }),
+  option: (provided, state) => ({
+    ...provided,
+    color: '#000',
+    backgroundColor: state.isFocused ? COLOR_APP_LIGHT : '#fff',
+    '&:hover': {
+      backgroundColor: COLOR_APP_LIGHT,
+    },
+  }),
 });

--- a/src/components/Categories/styles.js
+++ b/src/components/Categories/styles.js
@@ -70,7 +70,9 @@ export const CustomFormGroup = styled(FormGroup)({
 });
 
 export const CustomInputLabel = styled(InputLabel)({
-  marginBottom: '5px',
+  marginBottom: '10px',
+  color: (props) => (props.theme === 'dark' ? 'rgba(255,255,255,.7)' : 'rgba(0,0,0,.54)'),
+  fontSize: '0.75rem',
 });
 
 export const TableWrapper = styled(Container)({

--- a/src/components/Themes/Form.jsx
+++ b/src/components/Themes/Form.jsx
@@ -130,10 +130,10 @@ function ThemeForm(props) {
         </Box>
       </DialogContent>
       <DialogActions style={{ margin: 10 }}>
-        <Button variant="contained" onClick={() => close()}>
+        <Button variant="contained" size="small" onClick={close}>
           Fechar
         </Button>
-        <Button variant="contained" color="primary" onClick={save}>
+        <Button variant="contained" size="small" color="primary" onClick={save}>
           Salvar
         </Button>
       </DialogActions>

--- a/src/components/Themes/RemoveConfirmation.jsx
+++ b/src/components/Themes/RemoveConfirmation.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { themeType } from '@/types';
+import { themeType, appTheme } from '@/types';
 
 import {
   Dialog,
@@ -29,6 +29,7 @@ function RemoveConfirmation(props) {
     themesQuantity,
     page,
     callToast,
+    theme,
   } = props;
 
   const [loading, setLoading] = useState(false);
@@ -83,12 +84,12 @@ function RemoveConfirmation(props) {
       </DialogContent>
       <DialogActions>
         {!loading && (
-          <Button variant="contained" onClick={close}>
+          <Button variant={theme === 'dark' ? 'contained' : 'text'} size="small" onClick={close}>
             Fechar
           </Button>
         )}
         {!loading && (
-        <Button color="primary" variant="contained" onClick={remove}>
+        <Button color="primary" variant={theme === 'dark' ? 'contained' : 'text'} size="small" onClick={remove}>
           Excluir
         </Button>
         )}
@@ -104,13 +105,14 @@ RemoveConfirmation.propTypes = {
   themesQuantity: PropTypes.number.isRequired,
   page: PropTypes.number.isRequired,
   callToast: PropTypes.func.isRequired,
+  theme: appTheme.isRequired,
 };
 
 RemoveConfirmation.defaultProps = {
   open: false,
 };
 
-const mapStateToProps = (state) => ({ user: state.user, toast: state.config });
+const mapStateToProps = (state) => ({ user: state.user, toast: state.config, theme: state.theme });
 const mapDispatchToProps = (dispatch) => bindActionCreators({ callToast: ToastEmitter }, dispatch);
 
 export default connect(mapStateToProps, mapDispatchToProps)(RemoveConfirmation);

--- a/src/components/Themes/Themes.jsx
+++ b/src/components/Themes/Themes.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { userType } from '@/types';
+import { userType, appTheme } from '@/types';
 
 import {
   Container,
@@ -49,7 +49,10 @@ import {
 } from './styles';
 
 function Themes(props) {
-  const { user } = props;
+  const {
+    user,
+    theme,
+  } = props;
 
   const [themes, setThemes] = useState([]);
   const [loading, setLoading] = useState(false);
@@ -102,7 +105,7 @@ function Themes(props) {
     setOpenRemoveConfirm(isOpen);
   }
 
-  function selectTheme(theme, reason) {
+  function selectTheme(newTheme, reason) {
     return () => {
       switch (reason) {
         case 'remove': {
@@ -113,7 +116,7 @@ function Themes(props) {
           handleOpenForm(true);
         }
       }
-      setThemeSelected(theme);
+      setThemeSelected(newTheme);
     };
   }
 
@@ -255,23 +258,23 @@ function Themes(props) {
               </TableRow>
             </TableHead>
             <TableBody>
-              {themes.map((theme) => (
-                <TableRow key={theme._id}>
-                  <TableCell scope="name">{theme.name}</TableCell>
-                  <TableCell scope="alias">{theme.alias}</TableCell>
+              {themes.map((elem) => (
+                <TableRow key={elem._id}>
+                  <TableCell scope="name">{elem.name}</TableCell>
+                  <TableCell scope="alias">{elem.alias}</TableCell>
                   {user.tagAdmin && (
                   <TableCell scope="_id">
                     <CustomIconButton
                       icon="edit"
-                      color="primary"
+                      color={theme === 'dark' ? 'inherit' : 'primary'}
                       tooltip={<Typography component="span" variant="body2">Editar</Typography>}
-                      onClick={selectTheme(theme, 'edit')}
+                      onClick={selectTheme(elem, 'edit')}
                     />
                     <CustomIconButton
                       icon="delete_forever"
                       color="secondary"
                       tooltip={<Typography component="span" variant="body2">Remover</Typography>}
-                      onClick={selectTheme(theme, 'remove')}
+                      onClick={selectTheme(elem, 'remove')}
                     />
                   </TableCell>
                   )}
@@ -306,9 +309,10 @@ function Themes(props) {
 
 Themes.propTypes = {
   user: userType.isRequired,
+  theme: appTheme.isRequired,
 };
 
-const mapStateToProps = (state) => ({ user: state.user, toast: state.config });
+const mapStateToProps = (state) => ({ user: state.user, toast: state.config, theme: state.theme });
 const mapDispatchToProps = (dispatch) => bindActionCreators({ callToast: toastEmitter }, dispatch);
 
 export default connect(mapStateToProps, mapDispatchToProps)(Themes);

--- a/src/config/dataProperties.js
+++ b/src/config/dataProperties.js
@@ -29,7 +29,8 @@ export const SIMPLE_ERROR_MSG = 'Ocorreu um erro desconhecido, se persistir repo
 export const ERROR_MSG_CUSTOM = 'Ops, parece que ocorreu um erro. Tente recarregar a página, se persistir tente novamente mais tarde';
 
 export const COLOR_APP = '#8a05be';
-export const COLOR_APP_HOVER = 'rgba(145, 34, 189, .8)';
+export const COLOR_APP_HOVER = 'rgba(138, 5, 190, .8)';
+export const COLOR_APP_LIGHT = 'rgba(138, 5, 190,.2)';
 
 export const CAPTCHA_SITE_KEY = process.env.REACT_APP_SITE_KEY_CAPTCHA;
 /*


### PR DESCRIPTION
- [x] Added support to `dark theme` on themes section (included Dialogs, forms and lists) :wrench: 
- [x] Added support to `dark theme` on categories section (included Dialogs, forms and lists) :wrench:
- [x] Enhanced styles for `category input` provided by [react-select](react-select.com) dependency :rocket: 
- [x] Added more `COLOR_APP`s constants